### PR TITLE
More link in latest projects did not work

### DIFF
--- a/templates/modular/latest_projects.html.twig
+++ b/templates/modular/latest_projects.html.twig
@@ -49,7 +49,7 @@
           <div>{{ item.content }}</div>
 
           {% if item.header.link.url and item.header.link.title %}
-            <p><a class="more-link" href="{{ project.header.link.url }}"><i class="fa fa-external-link"></i> {{ item.header.link.title }}</a></p>
+            <p><a class="more-link" href="{{ item.header.link.url }}"><i class="fa fa-external-link"></i> {{ item.header.link.title }}</a></p>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
If a link for latest projects was given, the text always linked to the project page, not the specific item link